### PR TITLE
bits.Mul64

### DIFF
--- a/52_12/fixed.go
+++ b/52_12/fixed.go
@@ -8,6 +8,7 @@ package fixed // import "github.com/spacemeshos/fixed/52_12"
 import (
 	"fmt"
 	"math"
+	"math/bits"
 	"unsafe"
 )
 
@@ -73,6 +74,16 @@ func (x Fixed) Mul(y Fixed) Fixed {
 	ret += (xf * yf) >> fracBits           // Multiply fractions by each other.
 	ret += (xf * yf) >> (fracBits - 1) & 1 // Round to nearest, instead of rounding down.
 	return ret
+}
+
+func (x Fixed) Mul2(y Fixed) Fixed {
+	xs := x >> (totalBits - 1)                                 // x >= 0 ? 0 : -1
+	ys := y >> (totalBits - 1)                                 // y >= 0 ? 0 : -1
+	sign := 1 + 2*(xs^ys)                                      // x*y >= 0 ? 1 : -1
+	hi, lo := bits.Mul64(uint64((x^xs)-xs), uint64((y^ys)-ys)) // abs(x): (x^xs)-xs
+	rounding := (lo >> (fracBits - 1)) & 1
+	println(x.String(), y.String(), rounding, hi, lo, uint64((x^xs)-xs), uint64((y^ys)-ys))
+	return sign * Fixed(hi<<(totalBits-fracBits)|lo>>fracBits+rounding)
 }
 
 // Div returns x/y in fixed-point arithmetic.

--- a/52_12/fixed_test.go
+++ b/52_12/fixed_test.go
@@ -361,6 +361,26 @@ func TestFixedMulByOneMinusIota(t *testing.T) {
 	}
 }
 
+func TestFixed_Mul(t *testing.T) {
+	const (
+		oneMinusIota  = Fixed(1<<fracBits) - 1
+		oneMinusIotaF = float64(oneMinusIota) / (1 << fracBits)
+	)
+
+	i := uintptr(11)
+	x := -Fixed(1 << i)
+
+	xF := float64(x) / (1 << fracBits)
+	wantF := xF * oneMinusIotaF * (1 << fracBits)
+	want := Fixed(math.Floor(wantF + 0.5))
+
+	if got := x.Mul2(oneMinusIota); got != want {
+		t.Errorf("🛑 neg=%t, i=%d, x=%v, Mul: got %v, want %v", true, i, x, got, want)
+	} else {
+		t.Logf("✅ neg=%t, i=%d, x=%v, Mul: got %v, want %v", true, i, x, got, want)
+	}
+}
+
 func TestFixedMulVsMul(t *testing.T) {
 	if totalBits != 32 {
 		return
@@ -536,6 +556,15 @@ func BenchmarkFixed_Mul(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		x, y := Fixed(3*i), Fixed(i<<(fracBits-3))
 		r = x.Mul(y)
+	}
+	Result = r
+}
+
+func BenchmarkFixed_Mul2(b *testing.B) {
+	var r Fixed
+	for i := 0; i < b.N; i++ {
+		x, y := Fixed(3*i), Fixed(i<<(fracBits-3))
+		r = x.Mul2(y)
 	}
 	Result = r
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/spacemeshos/fixed
+
+go 1.12


### PR DESCRIPTION
This closes #1 

It currently only implements `Mul()` using the `bits` package, however, this degrades performance by an order of magnitude and also breaks one test case. If these issues can't be resolved this should not be merged. If they can, an implementation for `Div()` is also needed.