### PR TITLE
Add CI and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,33 @@
+name: Go
+
+on:
+  # Allow manually triggering this workflow
+  workflow_dispatch:
+  # run for all pull requests and pushes to certain branches
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        os: 
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+          - [self-hosted, linux-arm64]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        check-latest: true
+        go-version-file: "go.mod"
+    - name: Build
+      run: go build -v ./...
+    - name: Test
+      run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-.*
 *~

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/spacemeshos/fixed
 
-go 1.14
+go 1.19


### PR DESCRIPTION
Part of https://github.com/spacemeshos/pm/issues/242

This PR adds dependabot config for go modules and github actions/workflows as well as adds a basic CI that builds the code and runs the tests in the repository.