### PR TITLE
Update use of macos runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,14 +10,13 @@ on:
       - master
 
 jobs:
-
   build:
     strategy:
       matrix:
         os: 
           - ubuntu-latest
           - [self-hosted, linux-arm64]
-          - macos-latest
+          - macos-13
           - [self-hosted, macos, arm64]
           - windows-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
`macos-latest` is now a arm machine. Update to use an intel builder instead